### PR TITLE
Future schedule forward

### DIFF
--- a/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml
+++ b/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml
@@ -24,3 +24,14 @@
         </div>
     </div>
 }
+
+@section scripts
+{
+    <script type="text/javascript">
+        var whenField = document.getElementById('Data_When');
+        function updateMinValue() {
+            whenField.setAttribute('min', new Date().toISOString().substring(0, 19));
+        }
+        window.setInterval(updateMinValue, 10000);
+    </script>
+}

--- a/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml
+++ b/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml
@@ -16,7 +16,7 @@
         <hr/>
         @Html.HiddenFor(m => m.Data.TeamId)
         @Html.FormBlock(m => m.Data.PhoneNumber)
-        @Html.FormBlock(m => m.Data.When)
+        @Html.FormBlock(m => m.Data.When, inputModifier: tag => tag.Attr("min", DateTime.Now.ToString("s")).Attr("step", "1"))
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
                 <input type="submit" value="Create" class="btn btn-default"/>

--- a/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml.cs
+++ b/SupportManager.Web/Areas/Teams/Pages/ScheduleForward.cshtml.cs
@@ -21,6 +21,8 @@ namespace SupportManager.Web.Areas.Teams.Pages
 
         public async Task<IActionResult> OnPostAsync()
         {
+            if (Data.When <= DateTimeOffset.Now) return new BadRequestResult();
+
             await mediator.Send(Data);
 
             return this.RedirectToPageJson(nameof(Index), new { TeamId });


### PR DESCRIPTION
Prevent scheduling forwards for times in the past, which otherwise result in immediate execution by Hangfire. Fixes #16.